### PR TITLE
Allow choosing ATP PDS

### DIFF
--- a/atprototools/__init__.py
+++ b/atprototools/__init__.py
@@ -15,8 +15,11 @@ import unittest
 
 
 class Session():
-    def __init__(self, username, password):
-        self.ATP_HOST = "https://bsky.social"
+    def __init__(self, username, password, pds = None):
+        if pds: # check if pds is not empty
+            self.ATP_HOST = pds # use the given value
+        else:
+            self.ATP_HOST = "https://bsky.social" # use bsky.social by default
         self.ATP_AUTH_TOKEN = ""
         self.DID = ""
         self.USERNAME = username


### PR DESCRIPTION
Allows choosing the Personal Data server to use. If none is given, defaults to https://bsky.social. 