### PR TITLE
Parse DID correctly

### DIFF
--- a/atprototools/__init__.py
+++ b/atprototools/__init__.py
@@ -34,7 +34,7 @@ class Session():
         if self.ATP_AUTH_TOKEN == None:
             raise ValueError("No access token, is your password wrong? Do      export BSKY_PASSWORD='yourpassword'")
 
-        self.DID = resp.json().get("did")
+        self.DID = resp.json().get("did").split(":")[-1]
         # TODO DIDs expire shortly and need to be refreshed for any long-lived sessions
 
     def reskoot(self,url):


### PR DESCRIPTION
Previously, the code was not parsed the DID response correctly, resulting in incorrect data being parsed. This commit fixes the issue by properly splitting and parsing the DID.